### PR TITLE
build patterns before copying styleguide assets

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function build(config, patternsOnly = false) {
 		const patternlabInst = patternlab(config);
 
 		const onBuildComplete = () => {
-			resolve(buildCompleteStatusObj());
+			resolve(true);
 		};
 		
 		try {
@@ -41,16 +41,17 @@ function handleError(e, logger) {
 }
 
 function run(config, options) {
-
 	const buildPatternsOnly = options.source ? true : false;
 
-	const promise = buildPatternsOnly ?
-		build(config, buildPatternsOnly) :
-		styleguideManager.copyAssets(config.paths)
-			.then(() => build(config, buildPatternsOnly));
+	const buildPromise = build(config, buildPatternsOnly);
 
-	return promise
-		.catch(e => handleError(e, options.logger));
+	const finalPromise = buildPatternsOnly ? 
+		buildPromise : 
+		buildPromise.then(() => styleguideManager.copyAssets(config.paths));
+
+	return finalPromise
+			.then(buildCompleteStatusObj)
+			.catch(e => handleError(e, options.logger));
 }
 
 module.exports = function(){

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deg-skeletor/plugin-patternlab",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A Pattern Lab Skeletor plugin",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Pattern Lab really doesn't like it if the public/styleguide folder already exists when you tell it to build patterns, so I moved the styleguide assets copy step to happen after the patterns are build (rather than before).