### PR TITLE
only perform incremental builds when a pattern file changes

### DIFF
--- a/__mocks__/path.js
+++ b/__mocks__/path.js
@@ -1,9 +1,26 @@
+let relativeReturnVal = '';
+
 function resolve() {
 	return '';
 }
 
+function relative() {
+	return relativeReturnVal;
+}
+
+function __setRelativeReturnValue(returnVal) {
+	relativeReturnVal = returnVal;
+}
+
+function __reset() {
+	relativeReturnVal = '';
+}
+
 const path = {
-	resolve
+	resolve,
+	relative,
+	__setRelativeReturnValue,
+	__reset
 };
 
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const patternlab = require('patternlab-node');
 const styleguideManager = require('./lib/styleguideManager');
+const { isPatternFile } = require('./lib/utils');
 
 function buildCompleteStatusObj() {
 	return {
@@ -14,7 +15,7 @@ function buildErrorStatusObj(error) {
 	};''
 }
 
-function build(config, patternsOnly = false) {
+function build(config, patternsOnly = false, doIncrementalBuild = false) {
 	return new Promise((resolve, reject) => {
 		const patternlabInst = patternlab(config);
 
@@ -24,9 +25,9 @@ function build(config, patternsOnly = false) {
 		
 		try {
 			if(patternsOnly) {
-				patternlabInst.patternsonly(onBuildComplete);
+				patternlabInst.patternsonly(onBuildComplete, !doIncrementalBuild);
 			} else {
-				patternlabInst.build(onBuildComplete);
+				patternlabInst.build(onBuildComplete, !doIncrementalBuild);
 			}
 		} catch(e) {
 			reject(e);
@@ -43,7 +44,11 @@ function handleError(e, logger) {
 function run(config, options) {
 	const buildPatternsOnly = options.source ? true : false;
 
-	const buildPromise = build(config, buildPatternsOnly);
+	const doIncrementalBuild = options.source ? 
+		isPatternFile(options.source.filepath, config.paths.source) :
+		false;
+
+	const buildPromise = build(config, buildPatternsOnly, doIncrementalBuild);
 
 	const finalPromise = buildPatternsOnly ? 
 		buildPromise : 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,10 @@
+const path = require('path');
+
+function isPatternFile(filepath, sourcePaths) {
+	const relativePathToPatternsDir = path.relative(sourcePaths.patterns, filepath);
+	return !relativePathToPatternsDir.startsWith('..');
+}
+
+module.exports = {
+	isPatternFile
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deg-skeletor/plugin-patternlab",
-  "version": "0.1.2",
+  "version": "0.2.2",
   "description": "A Pattern Lab Skeletor plugin",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When files in the data, meta, and annotations directories change, incremental Pattern Lab builds don't re-build pattern files. The plugin now does a full build when these files change and only does an incremental build when a pattern file changes. 