### PR TITLE
use the PL build() method for incremental builds

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function buildErrorStatusObj(error) {
 	};''
 }
 
-function build(config, patternsOnly = false, doIncrementalBuild = false) {
+function build(config, doIncrementalBuild = false) {
 	return new Promise((resolve, reject) => {
 		const patternlabInst = patternlab(config);
 
@@ -24,11 +24,7 @@ function build(config, patternsOnly = false, doIncrementalBuild = false) {
 		};
 		
 		try {
-			if(patternsOnly) {
-				patternlabInst.patternsonly(onBuildComplete, !doIncrementalBuild);
-			} else {
-				patternlabInst.build(onBuildComplete, !doIncrementalBuild);
-			}
+			patternlabInst.build(onBuildComplete, !doIncrementalBuild);
 		} catch(e) {
 			reject(e);
 		}
@@ -42,15 +38,13 @@ function handleError(e, logger) {
 }
 
 function run(config, options) {
-	const buildPatternsOnly = options.source ? true : false;
-
 	const doIncrementalBuild = options.source ? 
 		isPatternFile(options.source.filepath, config.paths.source) :
 		false;
 
-	const buildPromise = build(config, buildPatternsOnly, doIncrementalBuild);
+	const buildPromise = build(config, doIncrementalBuild);
 
-	const finalPromise = buildPatternsOnly ? 
+	const finalPromise = doIncrementalBuild ? 
 		buildPromise : 
 		buildPromise.then(() => styleguideManager.copyAssets(config.paths));
 

--- a/index.test.js
+++ b/index.test.js
@@ -189,9 +189,9 @@ describe('When run() is invoked normally', () => {
 });
 
 describe('When run() is invoked as a result of a changed file', () => {
-	test('the Pattern Lab patternsonly() method is invoked for an incremental build', async () => {
+	test('the Pattern Lab build() method is invoked for an incremental build', async () => {
 		const patternlabInst = patternlab(validConfig);
-		const patternsOnlySpy = jest.spyOn(patternlabInst, 'patternsonly');
+		const buildSpy = jest.spyOn(patternlabInst, 'build');
 
 		const pluginOptions = {...patternsOnlyPluginOptions};
 		pluginOptions.source.filename = 'source/_patterns/pattern.mustache';
@@ -199,13 +199,13 @@ describe('When run() is invoked as a result of a changed file', () => {
 		path.__setRelativeReturnValue('pattern.mustache');
 
 		await patternlabPlugin().run(validConfig, patternsOnlyPluginOptions);
-		expect(patternsOnlySpy).toHaveBeenCalledTimes(1);
-		expect(patternsOnlySpy).toHaveBeenCalledWith(expect.any(Function), false);
+		expect(buildSpy).toHaveBeenCalledTimes(1);
+		expect(buildSpy).toHaveBeenCalledWith(expect.any(Function), false);
 	});
 
-	test('the Pattern Lab patternsonly() method is invoked for a full build', async () => {
+	test('the Pattern Lab build() method is invoked for a full build', async () => {
 		const patternlabInst = patternlab(validConfig);
-		const patternsOnlySpy = jest.spyOn(patternlabInst, 'patternsonly');
+		const buildSpy = jest.spyOn(patternlabInst, 'build');
 
 		const pluginOptions = {...patternsOnlyPluginOptions};
 		pluginOptions.source.filename = 'source/_data/data.json';
@@ -213,8 +213,8 @@ describe('When run() is invoked as a result of a changed file', () => {
 		path.__setRelativeReturnValue('../_data/data.json');
 
 		await patternlabPlugin().run(validConfig, patternsOnlyPluginOptions);
-		expect(patternsOnlySpy).toHaveBeenCalledTimes(1);
-		expect(patternsOnlySpy).toHaveBeenCalledWith(expect.any(Function), true);
+		expect(buildSpy).toHaveBeenCalledTimes(1);
+		expect(buildSpy).toHaveBeenCalledWith(expect.any(Function), true);
 	});
 
 	test('no styleguide assets are copied to the public folder', async () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deg-skeletor/plugin-patternlab",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A Pattern Lab Skeletor plugin",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The patternsonly() API method only builds patterns, not the "All" pages in Pattern Lab or the pattern navigation items. This plugin now uses the build() API method, which does build "All" pages and pattern nav items.