### PR TITLE
fixed incremental build logic so that pattern JSON files trigger a full build

### DIFF
--- a/__mocks__/path.js
+++ b/__mocks__/path.js
@@ -15,8 +15,16 @@ function join(val1, val2) {
 	return `${val1}/${val2}`;
 }
 
-function extname() {
-	return '.mustache';
+function extname(filepath) {
+	if(!filepath) {
+		return '';
+	}
+
+	const parts = filepath.split('.');
+	if(parts.length) {
+		return `.${parts[parts.length-1]}`;
+	}
+	return '';
 }
 
 function basename(path) {

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function handleError(e, logger) {
 
 async function run(config, options) {
 	const { patternLabConfig, patternExport } = config;
-
+	
 	const doIncrementalBuild = options.source ? 
 		isPatternFile(options.source.filepath, patternLabConfig.paths.source) :
 		false;

--- a/index.test.js
+++ b/index.test.js
@@ -194,39 +194,72 @@ describe('When run() is invoked normally', () => {
 	});
 });
 
-describe('When run() is invoked as a result of a changed file', () => {
-	test('the Pattern Lab build() method is invoked for an incremental build', async () => {
+describe('When run() is invoked as a result of a changed', () => {
+	test('pattern file, the Pattern Lab build() method is invoked for an incremental build', async () => {
 		const patternlabInst = patternlab(validConfig);
 		const buildSpy = jest.spyOn(patternlabInst, 'build');
 
 		const pluginOptions = {...patternsOnlyPluginOptions};
-		pluginOptions.source.filename = 'source/_patterns/pattern.mustache';
+		pluginOptions.source.filepath = 'source/_patterns/pattern.mustache';
 
 		path.__setRelativeReturnValue('pattern.mustache');
 
-		await patternlabPlugin().run(validConfig, patternsOnlyPluginOptions);
+		await patternlabPlugin().run(validConfig, pluginOptions);
 		expect(buildSpy).toHaveBeenCalledTimes(1);
 		expect(buildSpy).toHaveBeenCalledWith(expect.any(Function), false);
 	});
 
-	test('the Pattern Lab build() method is invoked for a full build', async () => {
+	test('meta pattern file, the Pattern Lab build() method is invoked for a full build', async () => {
 		const patternlabInst = patternlab(validConfig);
 		const buildSpy = jest.spyOn(patternlabInst, 'build');
 
 		const pluginOptions = {...patternsOnlyPluginOptions};
-		pluginOptions.source.filename = 'source/_data/data.json';
+		pluginOptions.source.filepath = 'source/_meta/_00-head.mustache';
 
-		path.__setRelativeReturnValue('../_data/data.json');
+		path.__setRelativeReturnValue('../_meta/_00-head.mustache');
 
-		await patternlabPlugin().run(validConfig, patternsOnlyPluginOptions);
+		await patternlabPlugin().run(validConfig, pluginOptions);
 		expect(buildSpy).toHaveBeenCalledTimes(1);
 		expect(buildSpy).toHaveBeenCalledWith(expect.any(Function), true);
 	});
 
-	test('no styleguide assets are copied to the public folder', async () => {
+	test('data.json file, the Pattern Lab build() method is invoked for a full build', async () => {
+		const patternlabInst = patternlab(validConfig);
+		const buildSpy = jest.spyOn(patternlabInst, 'build');
+
+		const pluginOptions = {...patternsOnlyPluginOptions};
+		pluginOptions.source.filepath = 'source/_data/data.json';
+
+		path.__setRelativeReturnValue('../_data/data.json');
+
+		await patternlabPlugin().run(validConfig, pluginOptions);
+		expect(buildSpy).toHaveBeenCalledTimes(1);
+		expect(buildSpy).toHaveBeenCalledWith(expect.any(Function), true);
+	});
+
+	test('pattern JSON file, the Pattern Lab build() method is invoked for a full build', async () => {
+		const patternlabInst = patternlab(validConfig);
+		const buildSpy = jest.spyOn(patternlabInst, 'build');
+
+		const pluginOptions = {...patternsOnlyPluginOptions};
+		pluginOptions.source.filepath = 'source/_patterns/04-pages/00-homepage.json';
+
+		path.__setRelativeReturnValue('./04-pages/00-homepage.json');
+
+		await patternlabPlugin().run(validConfig, pluginOptions);
+		expect(buildSpy).toHaveBeenCalledTimes(1);
+		expect(buildSpy).toHaveBeenCalledWith(expect.any(Function), true);
+	});
+
+	test('pattern file, no styleguide assets are copied to the public folder', async () => {
 		const copyAssetsSpy = jest.spyOn(styleguideManager, 'copyAssets');
 
-		await patternlabPlugin().run(validConfig, patternsOnlyPluginOptions);
+		const pluginOptions = {...patternsOnlyPluginOptions};
+		pluginOptions.source.filepath = 'source/_patterns/pattern.mustache';
+
+		path.__setRelativeReturnValue('pattern.mustache');
+
+		await patternlabPlugin().run(validConfig, pluginOptions);
 		expect(copyAssetsSpy).not.toHaveBeenCalled();
 	});
 });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 function isPatternFile(filepath, sourcePaths) {
-	if(path.extname(filepath) !== '.mustache') {
+	if(path.extname(filepath) === '.json') {
 		return false;
 	}
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,10 @@
 const path = require('path');
 
 function isPatternFile(filepath, sourcePaths) {
+	if(path.extname(filepath) !== '.mustache') {
+		return false;
+	}
+
 	const relativePathToPatternsDir = path.relative(sourcePaths.patterns, filepath);
 	return !relativePathToPatternsDir.startsWith('..');
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deg-skeletor/plugin-patternlab",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A Pattern Lab Skeletor plugin",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
If you have the watcher running and change a pattern's JSON file, it was not triggering a full Pattern Lab build. I changed the logic so that incremental builds only occur if a file changes inside of the _patterns directory AND the file must have a .mustache extension. Otherwise, a full build now occurs.