### PR TITLE
asset path replacement functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This plugin runs [Pattern Lab](http://patternlab.io) and is part of the Skeletor
 ## Installation
 Install this plugin into your Skeletor-equipped project via the following terminal command: 
 ```
-    npm install --save-dev git+https://git@github.com/deg-skeletor/skeletor-plugin-patternlab.git
+    npm install --save-dev @deg-skeletor/plugin-patternlab
 ```
 
 ## Configuration
@@ -12,19 +12,31 @@ Install this plugin into your Skeletor-equipped project via the following termin
 ### Example Configuration
 ```js
 {
-  "patternExport": [
-    {
-      patterns: 'components/*',
-      dest: './dist/patterns/',
-      includeHeadFoot: false
-    },
-    {
-      patterns: 'pages/*',
-      dest: './dist/patterns/',
-      includeHeadFoot: true
-    }
-  ],
-  "patternLabConfig": {
+  patternExport: {
+    patternGroups: [
+      {
+        patterns: 'components/*',
+        dest: './dist/patterns/',
+        includeHeadFoot: false
+      },
+      {
+        patterns: 'pages/*',
+        dest: './dist/patterns/',
+        includeHeadFoot: true
+      }
+    ],
+    assetPathReplacements: [
+      {
+        path: '../../images/',
+        replacementPath: '/images/'
+      },
+      {
+        path: '../../css/',
+        replacementPath: '/styles/'
+      }
+    ]
+  },  
+  patternLabConfig: {
     "cacheBust": true,
     "cleanPublic" : true,
     "defaultPattern": "all",
@@ -96,8 +108,16 @@ Install this plugin into your Skeletor-equipped project via the following termin
 ### Configuration Options
 
 #### patternExport
+Type: `Object`
+An optional configuration object for exporting patterns.
+
+#### patternExport.patternGroups
 Type: `Array`
-An array of one or more pattern group objects, each containing `patterns`, `dest`, and `includeHeadFoot` properties. 
+An array of one or more pattern group objects, each containing `patterns`, `dest`, and `includeHeadFoot` properties.
+
+#### patternExport.assetPathReplacements
+Type: `Array`
+An array of one or more asset path replacement objects, each containing `path` and `replacementPath` properties.
 
 #### patternLabConfig
 Type: `Object`

--- a/index.test.js
+++ b/index.test.js
@@ -268,13 +268,21 @@ describe('When run() is invoked with a patternExport configuration', () => {
 
 	const configWithExport = {
 		...validConfig,
-		patternExport: [
-			{
-				patterns: 'components/*',
-				dest: './dist/patterns/',
-				includeHeadFoot: true
-			}
-		]
+		patternExport: {
+			patternGroups: [
+				{
+					patterns: 'components/*',
+					dest: './dist/patterns/',
+					includeHeadFoot: true
+				}
+			],
+			assetPathReplacements: [
+				{
+					path: '../../images/',
+					replacementPath: '/images/'
+				}
+			]
+		}
 	};
 
 	test('the pattern exporter is invoked with the correct parameters', async () => {

--- a/lib/assetPathReplacer.js
+++ b/lib/assetPathReplacer.js
@@ -1,0 +1,10 @@
+function replaceAssetPaths(fileContents, assetPathReplacements) {
+    return assetPathReplacements.reduce((newFileContents, replacement) => {
+        const pathRegex = new RegExp(replacement.path, 'ig');
+        return newFileContents.replace(pathRegex, replacement.replacementPath);
+    }, fileContents);
+}
+
+module.exports = {
+    replaceAssetPaths
+};

--- a/lib/assetPathReplacer.test.js
+++ b/lib/assetPathReplacer.test.js
@@ -1,0 +1,59 @@
+const assetPathReplacer = require('./assetPathReplacer');
+
+test('Replaces single path', () => {
+    const assetPathReplacements = [{
+        path: '../../images/',
+        replacementPath: '/images/'
+    }];
+
+    const fileContents = '<img src="../../images/test.jpg" />';
+    const exepectedFileContents = '<img src="/images/test.jpg" />';
+
+    const newFileContents = assetPathReplacer.replaceAssetPaths(fileContents, assetPathReplacements);
+
+    expect(newFileContents).toBe(exepectedFileContents);
+});
+
+test('Replaces multiple paths', () => {
+    const assetPathReplacements = [{
+        path: '../../images/',
+        replacementPath: '/images/'
+    }];
+
+    const fileContents = `
+        <img src="../../images/test.jpg" />
+        <img src="../../images/test2.jpg" />`;
+    const exepectedFileContents = `
+        <img src="/images/test.jpg" />
+        <img src="/images/test2.jpg" />`;
+
+    const newFileContents = assetPathReplacer.replaceAssetPaths(fileContents, assetPathReplacements);
+
+    expect(newFileContents).toBe(exepectedFileContents);
+});
+
+test('Replaces multiple different paths', () => {
+    const assetPathReplacements = [
+        {
+            path: '../../images/',
+            replacementPath: '/images/'
+        },
+        {
+            path: '../../css/',
+            replacementPath: '/styles/'
+        }
+    ];
+
+    const fileContents = `
+        <link rel="stylesheet" type="text/css" href="../../css/styles.css">
+        <img src="../../images/test.jpg" />
+        <img src="../../images/test2.jpg" />`;
+    const exepectedFileContents = `
+        <link rel="stylesheet" type="text/css" href="/styles/styles.css">
+        <img src="/images/test.jpg" />
+        <img src="/images/test2.jpg" />`;
+
+    const newFileContents = assetPathReplacer.replaceAssetPaths(fileContents, assetPathReplacements);
+
+    expect(newFileContents).toBe(exepectedFileContents);
+});

--- a/lib/patternExporter.js
+++ b/lib/patternExporter.js
@@ -2,6 +2,8 @@ const fse = require('fs-extra');
 const glob = require('globby');
 const path = require('path');
 const beautifyHtml = require('js-beautify').html;
+const { compose } = require('./utils');
+const assetPathReplacer = require('./assetPathReplacer');
 
 const beautifierOptions = {
     preserve_newlines: false, 
@@ -84,20 +86,23 @@ async function writeFile(filepath, contents, logger) {
     }
 }
 
-async function exportPatternFile(patternFilepath, destDir, suffixRegExp, logger) {
+async function exportPatternFile(patternFilepath, destDir, assetPathReplacements, suffixRegExp, logger) {
     const destFilepath = getPatternDestFilepath(patternFilepath, destDir, suffixRegExp);
     const fileData = await readFile(patternFilepath, logger);
     
     if(fileData) {
-        const strippedFileData = stripPatternLabMarkup(fileData);
-        const beautifiedFileData = beautifyHtml(strippedFileData, beautifierOptions);
-        return await writeFile(destFilepath, beautifiedFileData, logger);
+        const replaceAssetPaths = fileData => assetPathReplacer.replaceAssetPaths(fileData, assetPathReplacements);
+        const beautify = fileData => beautifyHtml(fileData, beautifierOptions);
+        const processFileData = compose(beautify, replaceAssetPaths, stripPatternLabMarkup);
+        
+        const processedFileData = processFileData(fileData);
+        return await writeFile(destFilepath, processedFileData, logger);
     }
 
     return false;
 }
 
-async function exportPatternGroup(plConfig, patternGroupConfig, suffixRegExp, logger) { 
+async function exportPatternGroup(plConfig, patternGroupConfig, assetPathReplacements, suffixRegExp, logger) { 
     logger.info(`Exporting patterns for "${patternGroupConfig.patterns}".`);
 
     const globPattern = convertPatternMatcherToGlobPattern(patternGroupConfig.patterns, plConfig.paths.public.patterns);
@@ -105,7 +110,7 @@ async function exportPatternGroup(plConfig, patternGroupConfig, suffixRegExp, lo
    
     const promises = patternFilepaths
         .filter(filepath => filterPatternHtmlFile(filepath, patternGroupConfig.includeHeadFoot))
-        .map(filepath => exportPatternFile(filepath, patternGroupConfig.dest, suffixRegExp, logger));
+        .map(filepath => exportPatternFile(filepath, patternGroupConfig.dest, assetPathReplacements, suffixRegExp, logger));
 
     return Promise.all(promises)
         .then(results => results.every(result => result === true));
@@ -113,10 +118,11 @@ async function exportPatternGroup(plConfig, patternGroupConfig, suffixRegExp, lo
 
 function exportPatterns(plConfig, exportConfig, logger) {    
     const suffixRegExp = createPatternFileSuffixRegExp(plConfig.outputFileSuffixes);
+    const assetPathReplacements = exportConfig.assetPathReplacements || [];
 
     return Promise.all(
-        exportConfig.map(patternGroupConfig =>
-            exportPatternGroup(plConfig, patternGroupConfig, suffixRegExp, logger)
+        exportConfig.patternGroups.map(patternGroupConfig =>
+            exportPatternGroup(plConfig, patternGroupConfig, assetPathReplacements, suffixRegExp, logger)
         )
     ).then(results => results.every(result => result === true));
 }

--- a/lib/patternExporter.test.js
+++ b/lib/patternExporter.test.js
@@ -104,6 +104,10 @@ describe('When exportPatterns() is invoked', () => {
         }
     ];
 
+	const exportConfig = {
+		patternGroups: patternExportGroup
+	};
+
     test('it returns true when everything goes right', async () => {
         const globPattern = patternLabConfig.paths.public.patterns + '*/??-components-*';
 
@@ -111,7 +115,7 @@ describe('When exportPatterns() is invoked', () => {
 			[globPattern]: []
 		});
 
-        const result = await patternExporter.exportPatterns(patternLabConfig, patternExportGroup, logger);
+        const result = await patternExporter.exportPatterns(patternLabConfig, exportConfig, logger);
         expect(result).toBe(true);
     });
 
@@ -126,7 +130,7 @@ describe('When exportPatterns() is invoked', () => {
 			]
 		});
 
-        const result = await patternExporter.exportPatterns(patternLabConfig, patternExportGroup, logger);
+        const result = await patternExporter.exportPatterns(patternLabConfig, exportConfig, logger);
         expect(result).toBe(false);
     });
 
@@ -137,7 +141,7 @@ describe('When exportPatterns() is invoked', () => {
 			[globPattern]: []
 		});
 
-        await patternExporter.exportPatterns(patternLabConfig, patternExportGroup, logger);
+        await patternExporter.exportPatterns(patternLabConfig, exportConfig, logger);
         expect(fse.outputFile).toHaveBeenCalledTimes(0);
     });
 
@@ -164,7 +168,7 @@ describe('When exportPatterns() is invoked', () => {
 		fse.__setFileContents(sourceFilepaths.test, patternFileContents);
 		fse.__setFileContents(sourceFilepaths.test2, patternFileContents);
 
-		await patternExporter.exportPatterns(patternLabConfig, patternExportGroup, logger);
+		await patternExporter.exportPatterns(patternLabConfig, exportConfig, logger);
 		expect(fse.outputFile).toHaveBeenCalledTimes(2);
 		expect(fse.outputFile).toHaveBeenCalledWith(destFilepaths.test2, htmlFileContents);
         expect(fse.outputFile).toHaveBeenCalledWith(destFilepaths.test, htmlFileContents);
@@ -189,19 +193,21 @@ describe('When exportPatterns() is invoked', () => {
 
 		fse.__setFileContents(sourceFilepaths.test, patternFileContents);
 
-		await patternExporter.exportPatterns(patternLabConfig, patternExportGroup, logger);
+		await patternExporter.exportPatterns(patternLabConfig, exportConfig, logger);
 		expect(fse.outputFile).toHaveBeenCalledTimes(1);
 		expect(fse.outputFile).toHaveBeenCalledWith(destFilepaths.test, expect.any(String));
     });
     
-    test('a pattern is exported without head and foot content', async () => {
-        const patternExportGroupMarkupOnly = [
-            {
-                patterns: 'components/*',
-                dest: './dist/patterns/',
-                includeHeadFoot: false
-            }
-        ];
+    test('a pattern is exported without head and foot content', async () => {		
+		const exportConfigMarkupOnly = {
+			patternGroups: [
+				{
+					patterns: 'components/*',
+					dest: './dist/patterns/',
+					includeHeadFoot: false
+				}
+			]
+		}
 
 		const globPattern = patternLabConfig.paths.public.patterns + '*/??-components-*';
 	
@@ -213,18 +219,20 @@ describe('When exportPatterns() is invoked', () => {
 			]
 		});
 
-		await patternExporter.exportPatterns(patternLabConfig, patternExportGroupMarkupOnly, logger);
+		await patternExporter.exportPatterns(patternLabConfig, exportConfigMarkupOnly, logger);
 		expect(fse.readFile).not.toHaveBeenCalled();
     });
     
     test('a hidden pattern is not exported', async () => {
-        const patternExportGroupMarkupOnly = [
-            {
-                patterns: 'components/*',
-                dest: './dist/patterns/',
-                includeHeadFoot: false
-            }
-        ];
+        const exportConfigMarkupOnly = {
+			patternGroups: [
+				{
+					patterns: 'components/*',
+					dest: './dist/patterns/',
+					includeHeadFoot: false
+				}
+			]
+		};
 
 		const globPattern = patternLabConfig.paths.public.patterns + '*/??-components-*';
 	
@@ -246,8 +254,44 @@ describe('When exportPatterns() is invoked', () => {
 
 		fse.__setFileContents(sourceFilepaths.patternMarkupOnly, patternMarkupOnlyFileContents);
 
-		await patternExporter.exportPatterns(patternLabConfig, patternExportGroupMarkupOnly, logger);
+		await patternExporter.exportPatterns(patternLabConfig, exportConfigMarkupOnly, logger);
 		expect(fse.outputFile).toHaveBeenCalledTimes(1);
 		expect(fse.outputFile).toHaveBeenCalledWith(destFilepaths.test, htmlNoHeadFootFileContents);
 	});
+
+	test('a pattern is exported with replaced asset paths', async () => {		
+		const exportConfig = {
+			patternGroups: [
+				{
+					patterns: 'components/*',
+					dest: './dist/patterns/',
+					includeHeadFoot: true
+				}
+			],
+			assetPathReplacements: [
+				{
+					path: '../../css/',
+					replacementPath: '/css/'
+				}
+			]
+		}
+
+		const globPattern = patternLabConfig.paths.public.patterns + '*/??-components-*';
+
+		const sourceFilepath = 'dist/patterns/00-components-00-test/00-components-00-test.rendered.html';
+		const destFilepath = './dist/patterns/components/test.html';
+		
+		globby.__setPatternPaths({
+			[globPattern]: [
+				sourceFilepath
+			]
+		});
+
+		fse.__setFileContents(sourceFilepath, patternFileContents);
+
+		const replacedHtmlFileContents = htmlFileContents.replace('../../css/', '/css/');
+
+		await patternExporter.exportPatterns(patternLabConfig, exportConfig, logger);
+		expect(fse.outputFile).toHaveBeenCalledWith(destFilepath, replacedHtmlFileContents);
+    });
 });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,6 +9,11 @@ function isPatternFile(filepath, sourcePaths) {
 	return !relativePathToPatternsDir.startsWith('..');
 }
 
+function compose(...fns) {
+	return x => fns.reduceRight((v, f) => f(v), x);
+} 
+
 module.exports = {
-	isPatternFile
+	isPatternFile,
+	compose
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@deg-skeletor/plugin-patternlab",
-  "version": "1.1.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deg-skeletor/plugin-patternlab",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "A Pattern Lab Skeletor plugin",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The pattern exporter can now optionally replace asset paths in the file contents of the exported patterns. 

For example: if a pattern contained `<img src="../../images/test.jpg" />` (which is a valid image path inside of Pattern Lab), string replacement on the exported pattern could yield `<img src="/images/test.jpg" />`(which may be a valid image path outside of Pattern Lab).

To accommodate path replacement configuration. the `patternExport` configuration has changed from an array to an object:

`
                                "patternExport": {
					patternGroups: [
						{
							patterns: 'components/*',
							dest: './dist/patterns/',
							includeHeadFoot: true
						},
						{
							patterns: 'pages/*',
							dest: './dist/patterns/',
							includeHeadFoot: true
						}
					],
					assetPathReplacements: [
						{
							path: '../../images/',
							replacementPath: '/images/'
						}
					]
				}
`