### PR TITLE
configuration options for calling specific pattern lab methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,31 +11,7 @@ Install this plugin into your Skeletor-equipped project via the following termin
 
 ### Example Configuration
 ```js
-{
-  patternExport: {
-    patternGroups: [
-      {
-        patterns: 'components/*',
-        dest: './dist/patterns/',
-        includeHeadFoot: false
-      },
-      {
-        patterns: 'pages/*',
-        dest: './dist/patterns/',
-        includeHeadFoot: true
-      }
-    ],
-    assetPathReplacements: [
-      {
-        path: '../../images/',
-        replacementPath: '/images/'
-      },
-      {
-        path: '../../css/',
-        replacementPath: '/styles/'
-      }
-    ]
-  },  
+{ 
   patternLabConfig: {
     "cacheBust": true,
     "cleanPublic" : true,
@@ -101,13 +77,51 @@ Install this plugin into your Skeletor-equipped project via the following termin
       "density": "compact",
       "layout": "horizontal"
     }
+  },
+  method: 'build',
+  methodArgs: [],
+  patternExport: {
+    patternGroups: [
+      {
+        patterns: 'components/*',
+        dest: './dist/patterns/',
+        includeHeadFoot: false
+      },
+      {
+        patterns: 'pages/*',
+        dest: './dist/patterns/',
+        includeHeadFoot: true
+      }
+    ],
+    assetPathReplacements: [
+      {
+        path: '../../images/',
+        replacementPath: '/images/'
+      },
+      {
+        path: '../../css/',
+        replacementPath: '/styles/'
+      }
+    ]
   }
 }
 ```
 
 ### Configuration Options
 
-#### patternExport
+#### patternLabConfig
+Type: `Object`
+The configuratin object for Pattern Lab. See the [official Pattern Lab documentation](http://patternlab.io/docs/advanced-config-options.html) for configuration details.
+
+#### method (optional)
+Type: `String`
+The Pattern Lab method to execute. If omitted, this option defaults to `build`. Acceptable values include `build`, `patternsonly`, `version`, `help`, `liststarterkits`, and `loadstarterkit`.
+
+#### methodArgs (optional)
+Type: `Array`
+An array of arguments to pass to the Pattern Lab method specified in the `method` configuration option. For example, the value of this option could be `['@deg-skeletor/starterkit-mustache-default']` for the `loadstarterkit` method.
+
+#### patternExport (optional)
 Type: `Object`
 An optional configuration object for exporting patterns.
 
@@ -119,6 +133,3 @@ An array of one or more pattern group objects, each containing `patterns`, `dest
 Type: `Array`
 An array of one or more asset path replacement objects, each containing `path` and `replacementPath` properties.
 
-#### patternLabConfig
-Type: `Object`
-The configuratin object for Pattern Lab. See the [official Pattern Lab documentation](http://patternlab.io/docs/advanced-config-options.html) for configuration details.

--- a/__mocks__/patternlab-node.js
+++ b/__mocks__/patternlab-node.js
@@ -8,6 +8,9 @@ let buildError = null;
 function __reset() {
 	initError = null;
 	buildError = null;
+	instance.build.mockClear();
+	instance.patternsonly.mockClear();
+	instance.loadstarterkit.mockClear();
 }
 
 function __setInitError(error) {
@@ -30,8 +33,9 @@ patternlab.__setBuildError = __setBuildError;
 patternlab.__reset = __reset;
 
 const instance = {
-	build,
-	patternsonly: build
+	build: jest.fn(build),
+	patternsonly: jest.fn(build),
+	loadstarterkit: jest.fn()
 };
 
 patternlab.mockImplementation(options => {

--- a/index.test.js
+++ b/index.test.js
@@ -186,18 +186,16 @@ describe('When run() is invoked normally', () => {
 
 	test('the Pattern Lab build() method is invoked', async () => {
 		const patternlabInst = patternlab(validConfig);
-		const buildSpy = jest.spyOn(patternlabInst, 'build');
 
 		await patternlabPlugin().run(validConfig, pluginOptions);
-		expect(buildSpy).toHaveBeenCalledTimes(1);
-		expect(buildSpy).toHaveBeenCalledWith(expect.any(Function), true);
+		expect(patternlabInst.build).toHaveBeenCalledTimes(1);
+		expect(patternlabInst.build).toHaveBeenCalledWith(expect.any(Function), true);
 	});
 });
 
 describe('When run() is invoked as a result of a changed', () => {
 	test('pattern file, the Pattern Lab build() method is invoked for an incremental build', async () => {
 		const patternlabInst = patternlab(validConfig);
-		const buildSpy = jest.spyOn(patternlabInst, 'build');
 
 		const pluginOptions = {...patternsOnlyPluginOptions};
 		pluginOptions.source.filepath = 'source/_patterns/pattern.mustache';
@@ -205,13 +203,12 @@ describe('When run() is invoked as a result of a changed', () => {
 		path.__setRelativeReturnValue('pattern.mustache');
 
 		await patternlabPlugin().run(validConfig, pluginOptions);
-		expect(buildSpy).toHaveBeenCalledTimes(1);
-		expect(buildSpy).toHaveBeenCalledWith(expect.any(Function), false);
+		expect(patternlabInst.build).toHaveBeenCalledTimes(1);
+		expect(patternlabInst.build).toHaveBeenCalledWith(expect.any(Function), false);
 	});
 
 	test('meta pattern file, the Pattern Lab build() method is invoked for a full build', async () => {
 		const patternlabInst = patternlab(validConfig);
-		const buildSpy = jest.spyOn(patternlabInst, 'build');
 
 		const pluginOptions = {...patternsOnlyPluginOptions};
 		pluginOptions.source.filepath = 'source/_meta/_00-head.mustache';
@@ -219,13 +216,12 @@ describe('When run() is invoked as a result of a changed', () => {
 		path.__setRelativeReturnValue('../_meta/_00-head.mustache');
 
 		await patternlabPlugin().run(validConfig, pluginOptions);
-		expect(buildSpy).toHaveBeenCalledTimes(1);
-		expect(buildSpy).toHaveBeenCalledWith(expect.any(Function), true);
+		expect(patternlabInst.build).toHaveBeenCalledTimes(1);
+		expect(patternlabInst.build).toHaveBeenCalledWith(expect.any(Function), true);
 	});
 
 	test('data.json file, the Pattern Lab build() method is invoked for a full build', async () => {
 		const patternlabInst = patternlab(validConfig);
-		const buildSpy = jest.spyOn(patternlabInst, 'build');
 
 		const pluginOptions = {...patternsOnlyPluginOptions};
 		pluginOptions.source.filepath = 'source/_data/data.json';
@@ -233,13 +229,12 @@ describe('When run() is invoked as a result of a changed', () => {
 		path.__setRelativeReturnValue('../_data/data.json');
 
 		await patternlabPlugin().run(validConfig, pluginOptions);
-		expect(buildSpy).toHaveBeenCalledTimes(1);
-		expect(buildSpy).toHaveBeenCalledWith(expect.any(Function), true);
+		expect(patternlabInst.build).toHaveBeenCalledTimes(1);
+		expect(patternlabInst.build).toHaveBeenCalledWith(expect.any(Function), true);
 	});
 
 	test('pattern JSON file, the Pattern Lab build() method is invoked for a full build', async () => {
 		const patternlabInst = patternlab(validConfig);
-		const buildSpy = jest.spyOn(patternlabInst, 'build');
 
 		const pluginOptions = {...patternsOnlyPluginOptions};
 		pluginOptions.source.filepath = 'source/_patterns/04-pages/00-homepage.json';
@@ -247,8 +242,8 @@ describe('When run() is invoked as a result of a changed', () => {
 		path.__setRelativeReturnValue('./04-pages/00-homepage.json');
 
 		await patternlabPlugin().run(validConfig, pluginOptions);
-		expect(buildSpy).toHaveBeenCalledTimes(1);
-		expect(buildSpy).toHaveBeenCalledWith(expect.any(Function), true);
+		expect(patternlabInst.build).toHaveBeenCalledTimes(1);
+		expect(patternlabInst.build).toHaveBeenCalledWith(expect.any(Function), true);
 	});
 
 	test('pattern file, no styleguide assets are copied to the public folder', async () => {
@@ -291,5 +286,52 @@ describe('When run() is invoked with a patternExport configuration', () => {
 		await patternlabPlugin().run(configWithExport, pluginOptions);
 		expect(exportPatternsSpy).toHaveBeenCalledTimes(1);
 		expect(exportPatternsSpy).toHaveBeenCalledWith(configWithExport.patternLabConfig, configWithExport.patternExport, logger);
+	});
+});
+
+describe('When run() is invoked with a method is specified', () => {
+	
+	test('it runs the build method', async () => {
+		const configWithMethod = {
+			...validConfig,
+			method: 'build'
+		};
+
+		const patternlabInst = patternlab(validConfig);
+		await patternlabPlugin().run(configWithMethod, pluginOptions);
+
+		expect(patternlabInst.build).toHaveBeenCalledTimes(1);
+		expect(patternlabInst.build).toHaveBeenCalledWith(expect.any(Function), true);
+	});
+
+	test('it runs the patternsonly method', async () => {
+		const configWithMethod = {
+			...validConfig,
+			method: 'patternsonly'
+		};
+
+		const patternlabInst = patternlab(validConfig);
+
+		await patternlabPlugin().run(configWithMethod, pluginOptions);
+
+		expect(patternlabInst.patternsonly).toHaveBeenCalledTimes(1);
+		expect(patternlabInst.patternsonly).toHaveBeenCalledWith(expect.any(Function), true);
+	});
+
+	test('it runs the loadstarterkit method', async () => {
+		const starterkit = '@deg-skeletor/starterkit-mustache-default';
+		
+		const configWithMethod = {
+			...validConfig,
+			method: 'loadstarterkit',
+			methodArgs: [starterkit]
+		};
+
+		const patternlabInst = patternlab(validConfig);
+
+		await patternlabPlugin().run(configWithMethod, pluginOptions);
+
+		expect(patternlabInst.loadstarterkit).toHaveBeenCalledTimes(1);
+		expect(patternlabInst.loadstarterkit).toHaveBeenCalledWith(starterkit);
 	});
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@deg-skeletor/plugin-patternlab",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4847,9 +4847,9 @@
       }
     },
     "lodash": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
-      "integrity": "sha1-g+SxCRP0hJbU0W/sSlYK8u50S2g="
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -5510,6 +5510,11 @@
           "requires": {
             "graceful-fs": "^4.1.6"
           }
+        },
+        "lodash": {
+          "version": "4.13.1",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
+          "integrity": "sha1-g+SxCRP0hJbU0W/sSlYK8u50S2g="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deg-skeletor/plugin-patternlab",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "A Pattern Lab Skeletor plugin",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
You can now specify `method` and a `methodArgs` options in the configuration to run specific methods on the Pattern Lab API. This enhancement was needed primarily to run the loadstarterkit Pattern Lab method.